### PR TITLE
Adds GitHub Action Support, Fixes macOS FUSE Mount Errors (#5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,150 @@
+name: Build Rclone Browser
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      
+  workflow_dispatch:
+  
+jobs:
+  build_windows:
+    name: Windows Build
+    runs-on: windows-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Development Tools
+        run: |
+          choco install visualstudio2019community visualstudio2019-workload-nativedesktop cmake qt5-default -y
+          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          refreshenv
+          python get-pip.py
+          refreshenv
+          pip install py7zr lxml requests semantic-version
+          Remove-Item -Recurse -Force C:\Qt
+          mkdir C:\Qt
+          pushd C:\Qt
+          git clone https://github.com/engnr/qt-downloader.git
+          mv qt-downloader/qt-downloader .\qtd
+          Remove-Item -Recurse -Force qt-downloader
+          python qtd windows desktop 5.15.2 win64_msvc2019_64
+          popd
+          
+      - name: Build Rclone Browser
+        run: |
+          mkdir build
+          cd build
+          cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=C:\Qt\5.15.2\msvc2019_64 .. 
+          cmake --build . --config Release
+          C:\Qt\5.15.2\msvc2019_64\bin\windeployqt.exe --no-translations --no-angle --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: windows
+          path: build\build\Release\*
+          
+  build_linux:
+    name: Linux Build
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Development Tools
+        run: |
+          sudo apt update
+          sudo apt -y install git g++ cmake make qtdeclarative5-dev qtmultimedia5-dev
+      - name: Build Rclone Browser
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make -j $(nproc)
+          
+      - uses: actions/upload-artifact@v3
+        with:
+         name: linux
+         path: build/build/*
+         
+  build_macos:
+    name: macOS Build
+    runs-on: macos-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Development Tools
+        run: brew install git cmake rclone qt5
+      - name: Build Rclone Browser
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_PREFIX_PATH:PATH=/usr/local/opt/qt5
+          make -j $(nproc)
+          cd build
+          /usr/local/opt/qt@5/bin/macdeployqt rclone-browser.app -executable="rclone-browser.app/Contents/MacOS/rclone-browser" -qmldir=../src/
+          mv rclone-browser.app Rclone\ Browser.app
+      - uses: actions/upload-artifact@v3
+        with:
+          name: macos
+          path: build/build/*
+        
+  build_freebsd:
+    name: FreeBSD Build
+    runs-on: macos-12
+    
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Development Tools and Build Rclone Browser
+        uses: vmactions/freebsd-vm@v0
+        with:
+          mem: 4096
+          prepare: |
+            env ASSUME_ALWAYS_YES=YES pkg update -f
+            env ASSUME_ALWAYS_YES=YES pkg install -y git cmake qt5-buildtools qt5-declarative qt5-multimedia qt5-qmake
+            cd work/RcloneBrowser/RcloneBrowser
+            mkdir build
+            cd build
+            cmake ..
+            make
+            
+      - uses: actions/upload-artifact@v3
+        with:
+          name: freebsd
+          path: build/build/*
+
+  create_release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build_windows, build_linux, build_macos, build_freebsd]
+    
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create artifact directory
+        run: rm -rf /tmp/artifacts && mkdir /tmp/artifacts
+      - uses: actions/download-artifact@v3
+        with:
+          path: /tmp/artifacts
+      - name: Compress artifacts
+        run: |
+          pushd /tmp/artifacts
+          for i in *;do zip -r -0 $i.zip $i;done
+          popd
+          
+      - name: Get short commit
+        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+        
+      - uses: rickstaa/action-create-tag@v1
+        with:
+          tag: release-${{ env.SHORT_SHA }}
+          tag_exists_error: false
+          
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "/tmp/artifacts/*.zip"
+          name: Rclone Browser Autobuild For Commit ${{ env.SHORT_SHA }}
+          omitBody: true
+          generateReleaseNotes: true
+          prerelease: true
+          skipIfReleaseExists: true
+          tag: release-${{ env.SHORT_SHA }}
+        

--- a/src/remote_widget.cpp
+++ b/src/remote_widget.cpp
@@ -1424,7 +1424,7 @@ RemoteWidget::RemoteWidget(IconCache *iconCache, const QString &remote,
 #if defined(Q_OS_MACOS)
       // on macOS we check if FUSE for macOS is installed
 
-      const QFileInfo outputDir("/Library/Filesystems/osxfuse.fs/");
+      const QFileInfo outputDir("/Library/Filesystems/macfuse.fs/");
 
       if (outputDir.exists()) {
 


### PR DESCRIPTION
* Adds build action

I don't fully expect the Windows or Linux builds to work, but macOS should.

* Fixes naming on macOS, lists build directory on linux

* `osxfuse.fs` is now `macfuse.fs`

* fixes build naming, uploads linux artifact

Also fixes Windows Qt5 path

* Fix Qt on Windows

* Fix Python on Windows

* `python` not `python3.8` on actions

* Fixes Qt path for Windows

* Fix Remove-Item command

Also renames artifacts in preparation for releases

* Correct CMake Command

* Adds FreeBSD, OpenBSD, and NetBSD builds

* Gives FreeBSD, OpenBSD, and NetBSD jobs names

* Corrects BSD actions

* There is no sudo

* Fixes BSD package installation

* Adds more RAM to VMs, moves to correct dir

* Only execute this action on main or master

* Fix NetBSD Qt dependency problem

* Fix OpenBSD and NetBSD builds

* NetBSD Autoinstall

* Where does Windows put the binary?

* Fix Windows artifacts, adds NetBSD MesaLib

* Hopefully fixes NetBSD

* Install QtMultimedia for NetBSD

* Add OpenGL Libraries

* Removes NetBSD

I can't figure it out. I'll leave it to someone much smarter than me

* Adds automatic GitHub Release action

* Fix release action

* Removes OpenBSD

I'm not smart enough for this

* Fix release action

* Create GitHub tag before release

* Adds actions checkout

* Fixes release action

* Don't compress the macOS app

It causes issues with releases

* Remove directories that might exist before population